### PR TITLE
Update docker-container-actions.ts

### DIFF
--- a/src/docker-container-actions.ts
+++ b/src/docker-container-actions.ts
@@ -57,14 +57,14 @@ module.exports = function (RED: Red) {
                                 let eventEmmiter = null
 
                                 if (config.deletecontainer) {//@ts-ignore
-                                    eventEmmiter = client.run(image, ['sh', '-c', config.cmd], false, Object.assign(config.startOptions, { "HostConfig": { "AutoRemove": true } }), (err, _data, _container) => {
+                                    eventEmmiter = client.run(image, config.cmd, false, Object.assign(config.startOptions, { "HostConfig": { "AutoRemove": true } }), (err, _data, _container) => {
                                         if (err) {
                                             node.error(err, msg);
                                             node.send(Object.assign(msg, { payload: {}, err: err }))
                                         }
                                     })
                                 } else {//@ts-ignore
-                                    eventEmmiter = client.run(image, ['sh', '-c', config.cmd], false, config.createOptions, config.startOptions, (err: any, _data: any, _container: any) => {
+                                    eventEmmiter = client.run(image, config.cmd, false, config.createOptions, config.startOptions, (err: any, _data: any, _container: any) => {
                                         if (err) {
                                             node.error(err, msg);
                                             node.send(Object.assign(msg, { payload: {}, err: err }))
@@ -85,14 +85,14 @@ module.exports = function (RED: Red) {
                         let eventEmmiter = null
 
                         if (config.deletecontainer) {//@ts-ignore
-                            eventEmmiter = client.run(image, ['sh', '-c', config.cmd], false, Object.assign(config.startOptions, { "HostConfig": { "AutoRemove": true } }), (err, _data, _container) => {
+                            eventEmmiter = client.run(image, config.cmd, false, Object.assign(config.startOptions, { "HostConfig": { "AutoRemove": true } }), (err, _data, _container) => {
                                 if (err) {
                                     node.error(err, msg);
                                     node.send(Object.assign(msg, { payload: {}, err: err }))
                                 }
                             })
                         } else {//@ts-ignore
-                            eventEmmiter = client.run(image, ['sh', '-c', config.cmd], false, config.createOptions, config.startOptions, (err: any, _data: any, _container: any) => {
+                            eventEmmiter = client.run(image, config.cmd, false, config.createOptions, config.startOptions, (err: any, _data: any, _container: any) => {
                                 if (err) {
                                     node.error(err, msg);
                                     node.send(Object.assign(msg, { payload: {}, err: err }))
@@ -111,7 +111,7 @@ module.exports = function (RED: Red) {
 
                 case 'exec':
                     let execOptions = {
-                        Cmd: ['sh', '-c', options],
+                        Cmd: options,
                         AttachStdout: true,
                         AttachStderr: true
                     };


### PR DESCRIPTION
Hi,
When you run or exec a container, you can pass command argument to the command line. the official api takes an array of string in argument (see cmd argument reference *). In your implementation you are assuming that every command should be run via sh -c and so you are building an array of string with the command line "sh -c". Even if it is easier for the consumer, as a single string can be used with space in it to defined the cmd, it does not comply with docker api and it is not as flexible as desired. Especially if the container does not embed sh, it will fail to execute. Proposition is made to change the variable type from string to array of string by omiting the ['sh','-c' ... ]. This will allow one to use the full power of docker run/exec by letting the array of string to be build by the consumer.

Exemple with rancher/cli2 container : 

$ docker run rancher/cli2 sh -c '--version'
No help topic for 'sh'

$ docker run rancher/cli2 --version
rancher version v2.7.0

i am not sure what is the best way to overcome this.
My merge request is a breaking change for existing flows as it will allow/require an array of string instead of a string and shell command who needs to be call via sh -c  wont work anymore out of the box 

*https://docs.docker.com/engine/api/v1.41/#tag/Exec/operation/ContainerExec *https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerCreate